### PR TITLE
Fix tables becoming sequence diagrams

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.2.7 (2019-11-20)
+-----------------
+
+* Fix case where '|||' in a table started a sequence diagram.
+
 0.2.6 (2019-06-12)
 ------------------
 

--- a/docdown/__init__.py
+++ b/docdown/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Jason Emerick"""
 __email__ = 'jason@mobelux.com'
-__version__ = '0.2.6'
+__version__ = '__version__ = '__version__ = '__version__ = '0.2.7''''

--- a/docdown/__init__.py
+++ b/docdown/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Jason Emerick"""
 __email__ = 'jason@mobelux.com'
-__version__ = '__version__ = '__version__ = '__version__ = '0.2.7''''
+__version__ = '0.2.7'

--- a/docdown/sequence.py
+++ b/docdown/sequence.py
@@ -14,7 +14,7 @@ DEFAULT_ADAPTER = 'docdown.template_adapters.StringFormatAdapter'
 
 class SequenceDiagramBlockPreprocessor(TemplateRenderMixin, Preprocessor):
 
-    RE = re.compile(r'\|{3,}\s*?\n(?P<content>[\s\S\n]*?)!(\[(?P<title>.*)\])?\((?P<url>\S*)\)\n\|{3,}', re.MULTILINE)
+    RE = re.compile(r'^\s*\|{3,}\s*?\n(?P<content>[\s\S\n]*?)!(\[(?P<title>.*)\])?\((?P<url>\S*)\)\n\|{3,}', re.MULTILINE)
 
     def __init__(self, media_url=None, prefix='', postfix='', template_adapter=DEFAULT_ADAPTER, **kwargs):
         self.media_url = media_url

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,581 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, `new` is for `{}` formatting,and `fstr` is for f-strings.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=130
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.6
+current_version = 0.2.7
 commit = True
 tag = True
 
@@ -17,3 +17,4 @@ universal = 1
 [flake8]
 exclude = docs,docdown/template_adapters/__init__.py
 max-line-length = 120
+

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='docdown',
-    version='0.2.6',
+    version='version='version='version='0.2.7'''',
     description="DocDown is a Markdown extension for source code documentation.",
     long_description=readme + '\n\n' + history,
     author="Jason Emerick, Justin Michalicek",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
 
 setup(
     name='docdown',
-    version='version='version='version='0.2.7'''',
+    version='0.2.7',
     description="DocDown is a Markdown extension for source code documentation.",
     long_description=readme + '\n\n' + history,
     author="Jason Emerick, Justin Michalicek",

--- a/tests/test_sequence_diagram_extension.py
+++ b/tests/test_sequence_diagram_extension.py
@@ -9,8 +9,10 @@ Tests for `docdown.sequence` module.
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-import markdown
 import unittest
+
+# pylint apparently confused because pip name is 'Markdown'
+import markdown  # pylint: disable=import-error
 
 from docdown.sequence import SequenceDiagramBlockPreprocessor
 
@@ -117,14 +119,14 @@ class SequenceDiagramExtensionTest(unittest.TestCase):
         Test that multiple sequence diagrams in a row render correctly
         """
         text = ('# Sequence Diagrams\n'
-               '|||\n'
-               'Activate App 1\n'
-               '![Activate App Sequence Diagram 1](./assets/ActivateAppSuccessfulResume.png)\n'
-               '|||\n\n'
-               '|||\n'
-               'Activate App 2\n'
-               '![Activate App Sequence Diagram 2](./assets/ActivateAppSuccessfulResume.png)\n'
-               '|||')
+                '|||\n'
+                'Activate App 1\n'
+                '![Activate App Sequence Diagram 1](./assets/ActivateAppSuccessfulResume.png)\n'
+                '|||\n\n'
+                '|||\n'
+                'Activate App 2\n'
+                '![Activate App Sequence Diagram 2](./assets/ActivateAppSuccessfulResume.png)\n'
+                '|||')
 
         html = markdown.markdown(
             text,
@@ -159,7 +161,6 @@ class SequenceDiagramExtensionTest(unittest.TestCase):
         """
         Test that sequences of `'|||'` in table structures do not start a sequence diagram.
         """
-        self.maxDiff = None
         text = ('|id|name|phone|email|address|\n'
                 '|:---|:---|:--------|:---------|:----------|\n'
                 '|0|bob|911|bob@gmail.com||\n'
@@ -178,15 +179,19 @@ class SequenceDiagramExtensionTest(unittest.TestCase):
         )
 
         expected_output = (
-            '''<p>|id|name|phone|email|address|
-|:---|:---|:--------|:---------|:----------|
-|0|bob|911|bob@gmail.com||
-|1|alice|248|||</p>
-<div class="visual-link-wrapper"><a href="#" data-src="http://example.com/../assets/img/user_registration.diagram" class="visual-link"><div class="visual-link__body"><div class="t-h6 visual-link__title">UserRegistration</div><p class="t-default">
-
-<p>User Registration Diagram</p>
-</p></div><div class="visual-link__link fx-wrapper fx-s-between fx-a-center"><span class="fc-theme">View Diagram</span><span class="icon">{% svg "standard/icon-visual" %}</span></div></a></div>
-<img class="visual-print-image" src="http://example.com/../assets/img/user_registration.diagram">'''
+            '<p>|id|name|phone|email|address|\n'
+            '|:---|:---|:--------|:---------|:----------|\n'
+            '|0|bob|911|bob@gmail.com||\n'
+            '|1|alice|248|||</p>\n'
+            # note long line wrapped
+            '<div class="visual-link-wrapper"><a href="#" data-src="http://example.com/../assets/img/user_registration.diagram"'
+            ' class="visual-link"><div class="visual-link__body"><div class="t-h6 visual-link__title">UserRegistration</div>'
+            '<p class="t-default">\n'
+            '\n'
+            '<p>User Registration Diagram</p>\n'
+            '</p></div><div class="visual-link__link fx-wrapper fx-s-between fx-a-center"><span class="fc-theme">'
+            'View Diagram</span><span class="icon">{% svg "standard/icon-visual" %}</span></div></a></div>\n'
+            '<img class="visual-print-image" src="http://example.com/../assets/img/user_registration.diagram">'
         )
 
         self.assertEqual(html, expected_output)
@@ -296,12 +301,12 @@ class SequenceDiagramBlockPreprocessorTest(unittest.TestCase):
         # each element in the list is treated as a line and so a newline is inserted
         # adding an extra empty line between each element
         expected = ['# Sequence Diagrams', '',
-                '\x02wzxhzdk:0\x03',
-                '',
-                'Activate App', '',
-                '\x02wzxhzdk:1\x03',
-                ''
-                ]
+                    '\x02wzxhzdk:0\x03',
+                    '',
+                    'Activate App', '',
+                    '\x02wzxhzdk:1\x03',
+                    ''
+                    ]
 
         self.assertEqual(processed, expected)
 
@@ -323,10 +328,10 @@ class SequenceDiagramBlockPreprocessorTest(unittest.TestCase):
         # each element in the list is treated as a line and so a newline is inserted
         # adding an extra empty line between each element
         expected = ['# Sequence Diagrams', '',
-                '\x02wzxhzdk:0\x03',
-                '',
-                'Activate App', '',
-                '\x02wzxhzdk:1\x03',
-                ''
-                ]
+                    '\x02wzxhzdk:0\x03',
+                    '',
+                    'Activate App', '',
+                    '\x02wzxhzdk:1\x03',
+                    ''
+                    ]
         self.assertEqual(processed, expected)

--- a/tests/test_sequence_diagram_extension.py
+++ b/tests/test_sequence_diagram_extension.py
@@ -155,6 +155,42 @@ class SequenceDiagramExtensionTest(unittest.TestCase):
 
         self.assertEqual(html, expected_output)
 
+    def test_table_not_sequence_diagram(self):
+        """
+        Test that sequences of `'|||'` in table structures do not start a sequence diagram.
+        """
+        self.maxDiff = None
+        text = ('|id|name|phone|email|address|\n'
+                '|:---|:---|:--------|:---------|:----------|\n'
+                '|0|bob|911|bob@gmail.com||\n'
+                '|1|alice|248|||\n'
+                '\n'
+                '|||\n'
+                'User Registration Diagram\n'
+                '![UserRegistration](../assets/img/user_registration.diagram)\n'
+                '|||\n')
+
+        html = markdown.markdown(
+            text,
+            extensions=self.MARKDOWN_EXTENSIONS,
+            extension_configs=self.EXTENSION_CONFIGS,
+            output_format='html5'
+        )
+
+        expected_output = (
+            '''<p>|id|name|phone|email|address|
+|:---|:---|:--------|:---------|:----------|
+|0|bob|911|bob@gmail.com||
+|1|alice|248|||</p>
+<div class="visual-link-wrapper"><a href="#" data-src="http://example.com/../assets/img/user_registration.diagram" class="visual-link"><div class="visual-link__body"><div class="t-h6 visual-link__title">UserRegistration</div><p class="t-default">
+
+<p>User Registration Diagram</p>
+</p></div><div class="visual-link__link fx-wrapper fx-s-between fx-a-center"><span class="fc-theme">View Diagram</span><span class="icon">{% svg "standard/icon-visual" %}</span></div></a></div>
+<img class="visual-print-image" src="http://example.com/../assets/img/user_registration.diagram">'''
+        )
+
+        self.assertEqual(html, expected_output)
+
     def test_sequence_diagram_with_protocol_relative_path(self):
         """
         Test a single sequence diagram renders correctly.


### PR DESCRIPTION
Adds test for case where occurrence of '|||' in a table incorrectly starts a sequence diagram. Fixes test case by requiring '|||' to be the only thing on the line (except for whitespace).