### PR TITLE
All fixes needed to properly scope the code tabs to only within `|~ .. ~|` blocks

### DIFF
--- a/docdown/scoped_code_tabs.py
+++ b/docdown/scoped_code_tabs.py
@@ -20,6 +20,15 @@ class ScopedCodeTabsPreprocessor(Preprocessor):
         self.code_tabs_preprocessor = code_tabs_preprocessor
         super(ScopedCodeTabsPreprocessor, self).__init__(md)
 
+    def pre_run_code_tab_preprocessor(self, lines):
+        """
+        Mark the code block for code tab pre-processing but hold off on rendering the tabs
+            until all are processed so that the HTML tab group indexing will work properly in
+            a global context
+        """
+        self.code_tabs_preprocessor.codehilite_config = self.code_tabs_preprocessor._get_codehilite_config()
+        return self.code_tabs_preprocessor._parse_code_blocks('\n'.join(lines))
+
     def run(self, lines):
         new_lines = []
         fenced_code_tab = []
@@ -33,7 +42,7 @@ class ScopedCodeTabsPreprocessor(Preprocessor):
                 starting_line = line
             elif re.search(self.RE_FENCE_END, line):
                 # End of code block, run through fenced code tabs pre-processor and reset code tab list
-                new_lines += self.code_tabs_preprocessor.run(fenced_code_tab)
+                new_lines.append(self.pre_run_code_tab_preprocessor(fenced_code_tab))
                 fenced_code_tab = []
                 in_tab = False
             elif in_tab:
@@ -46,7 +55,9 @@ class ScopedCodeTabsPreprocessor(Preprocessor):
         # Non-terminated code tab block, append matching starting fence and remaining lines without processing
         if fenced_code_tab:
             new_lines += [starting_line] + fenced_code_tab
-        return new_lines
+
+        # Finally, run the whole thing through the code tabs rendering function
+        return self.code_tabs_preprocessor._render_code_tabs('\n'.join(new_lines)).split('\n')
 
 
 class ScopedCodeTabExtension(CodeTabsExtension):
@@ -81,12 +92,25 @@ class ScopedCodeTabExtension(CodeTabsExtension):
         super(ScopedCodeTabExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md, md_globals):
-        super(ScopedCodeTabExtension, self).extendMarkdown(md, md_globals)
+        # The parent class will replace the fenced_code_block preprocessor in its extendMarkdown.
+        #   In order for this to be truly a scoped extension, we need to replace it back with the base
+        #   if one exists, or remove it entirely.
+        if 'fenced_code_block' in md.preprocessors:
+            base_fenced_code_preprocessor = md.preprocessors.get('fenced_code_block')
+            super(ScopedCodeTabExtension, self).extendMarkdown(md, md_globals)
+
+            code_tabs_preprocessor = md.preprocessors['fenced_code_block']
+            md.preprocessors['fenced_code_block'] = base_fenced_code_preprocessor
+        else:
+            super(ScopedCodeTabExtension, self).extendMarkdown(md, md_globals)
+            code_tabs_preprocessor = md.preprocessors['fenced_code_block']
+            del md.preprocessors['fenced_code_block']
+
         md.registerExtension(self)
 
         md.preprocessors.add('scoped_code_tabs',
                              ScopedCodeTabsPreprocessor(md,
-                                                        code_tabs_preprocessor=md.preprocessors['fenced_code_block']),
+                                                        code_tabs_preprocessor=code_tabs_preprocessor),
                              ">normalize_whitespace")
 
 

--- a/docdown/scoped_code_tabs.py
+++ b/docdown/scoped_code_tabs.py
@@ -88,7 +88,6 @@ class ScopedCodeTabExtension(CodeTabsExtension):
                              ScopedCodeTabsPreprocessor(md,
                                                         code_tabs_preprocessor=md.preprocessors['fenced_code_block']),
                              ">normalize_whitespace")
-        del md.preprocessors['fenced_code_block']
 
 
 def makeExtension(*args, **kwargs):

--- a/docdown/scoped_code_tabs.py
+++ b/docdown/scoped_code_tabs.py
@@ -32,6 +32,7 @@ class ScopedCodeTabsPreprocessor(Preprocessor):
     def run(self, lines):
         new_lines = []
         fenced_code_tab = []
+        tab_break_line = "<!-- SCOPED_TAB_BREAK-->"
         starting_line = None
         in_tab = False
 
@@ -42,6 +43,8 @@ class ScopedCodeTabsPreprocessor(Preprocessor):
                 starting_line = line
             elif re.search(self.RE_FENCE_END, line):
                 # End of code block, run through fenced code tabs pre-processor and reset code tab list
+                # Add <!-- SCOPED_TAB_BREAK--> content break to separate potentially subsequent tab groups
+                new_lines.append(tab_break_line)
                 new_lines.append(self.pre_run_code_tab_preprocessor(fenced_code_tab))
                 fenced_code_tab = []
                 in_tab = False
@@ -57,7 +60,8 @@ class ScopedCodeTabsPreprocessor(Preprocessor):
             new_lines += [starting_line] + fenced_code_tab
 
         # Finally, run the whole thing through the code tabs rendering function
-        return self.code_tabs_preprocessor._render_code_tabs('\n'.join(new_lines)).split('\n')
+        return [line for line in self.code_tabs_preprocessor._render_code_tabs('\n'.join(new_lines)).split('\n') if
+                line != tab_break_line]
 
 
 class ScopedCodeTabExtension(CodeTabsExtension):

--- a/tests/test_scoped_code_tabs.py
+++ b/tests/test_scoped_code_tabs.py
@@ -73,14 +73,14 @@ def hello_world(name: str = None):
 </code></pre></div></div>
 
 <h3>A regular, non-tabbed code block in Bash</h3>
-<p><code>bash
-codeblockinfo() {
-    echo("This would NOT be passed through markdown_fenced_code_tabs");
-}</code></p>
-<p><code>clojure
-(defn code-block-info []
-   (println "This should also render as a normal code block"))
-(hello-world)</code></p>
+<div class=md-fenced-code-tabs id=tab-tab-group-0><input name=tab-group-0 type=radio id=tab-group-0-0_bash checked=checked class=code-tab data-lang=bash aria-controls=tab-group-0-0_bash-panel role=tab><label for=tab-group-0-0_bash class=code-tab-label data-lang=bash id=tab-group-0-0_bash-label>Bash</label><div class=code-tabpanel role=tabpanel data-lang=bash id=tab-group-0-0_bash-panel aria-labelledby=tab-group-0-0_bash-label><pre><code class=bash>codeblockinfo() {
+    echo(&quot;This would NOT be passed through markdown_fenced_code_tabs&quot;);
+}
+</code></pre></div><input name=tab-group-0 type=radio id=tab-group-0-1_clojure class=code-tab data-lang=clojure aria-controls=tab-group-0-1_clojure-panel role=tab><label for=tab-group-0-1_clojure class=code-tab-label data-lang=clojure id=tab-group-0-1_clojure-label>Clojure</label><div class=code-tabpanel role=tabpanel data-lang=clojure id=tab-group-0-1_clojure-panel aria-labelledby=tab-group-0-1_clojure-label><pre><code class=clojure>(defn code-block-info []
+   (println &quot;This should also render as a normal code block&quot;))
+(hello-world)
+</code></pre></div></div>
+
 <h4>(White-space fences are OK)</h4>
 <div class=md-fenced-code-tabs id=tab-tab-group-0><input name=tab-group-0 type=radio id=tab-group-0-0_html checked=checked class=code-tab data-lang=html aria-controls=tab-group-0-0_html-panel role=tab><label for=tab-group-0-0_html class=code-tab-label data-lang=html id=tab-group-0-0_html-label>Html</label><div class=code-tabpanel role=tabpanel data-lang=html id=tab-group-0-0_html-panel aria-labelledby=tab-group-0-0_html-label><pre><code class=html>&lt;html&gt;
 &lt;head&gt;&lt;/head&gt;
@@ -131,3 +131,75 @@ def hello_world(greeting: str = 'World'):
 
         self.maxDiff = len(html) * 2
         self.assertEqual(html, expected_output)
+
+    def test_fenced_code_mixed_hilite(self):
+        text = """\
+|~
+```objc
+#import <Foundation/Foundation.h>
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        // insert code here...
+        NSLog(@"Hello, World!");
+    }
+    return 0;
+}
+```
+
+```swift
+// Hello, World! Program
+import Swift
+print("Hello, World!")
+```
+~|
+
+```xml
+<interface name="string" version="string" minVersion="string" date="string">
+  <!--Zero or more repetitions:-->
+  <enum/>
+  <!--Zero or more repetitions:-->
+  <struct/>
+  <!--Zero or more repetitions:-->
+  <function/>
+</interface>
+```
+"""
+
+        html = markdown.markdown(
+            text,
+            extensions=[
+                'markdown.extensions.fenced_code',
+                'markdown.extensions.codehilite',
+                'docdown.scoped_code_tabs',
+            ],
+            output_format='html5')
+
+        expected_output = """\
+<div class=md-fenced-code-tabs id=tab-tab-group-0><input name=tab-group-0 type=radio id=tab-group-0-0_objc checked=checked class=code-tab data-lang=objc aria-controls=tab-group-0-0_objc-panel role=tab><label for=tab-group-0-0_objc class=code-tab-label data-lang=objc id=tab-group-0-0_objc-label>Objc</label><div class=code-tabpanel role=tabpanel data-lang=objc id=tab-group-0-0_objc-panel aria-labelledby=tab-group-0-0_objc-label><div class=codehilite><pre><span></span><span class=cp>#import &lt;Foundation/Foundation.h&gt;</span>
+
+<span class=kt>int</span> <span class=nf>main</span><span class=p>(</span><span class=kt>int</span> <span class=n>argc</span><span class=p>,</span> <span class=k>const</span> <span class=kt>char</span> <span class=o>*</span> <span class=n>argv</span><span class=p>[])</span> <span class=p>{</span>
+    <span class=k>@autoreleasepool</span> <span class=p>{</span>
+        <span class=c1>// insert code here...</span>
+        <span class=n>NSLog</span><span class=p>(</span><span class=s>@&quot;Hello, World!&quot;</span><span class=p>);</span>
+    <span class=p>}</span>
+    <span class=k>return</span> <span class=mi>0</span><span class=p>;</span>
+<span class=p>}</span>
+</pre></div></div><input name=tab-group-0 type=radio id=tab-group-0-1_swift class=code-tab data-lang=swift aria-controls=tab-group-0-1_swift-panel role=tab><label for=tab-group-0-1_swift class=code-tab-label data-lang=swift id=tab-group-0-1_swift-label>Swift</label><div class=code-tabpanel role=tabpanel data-lang=swift id=tab-group-0-1_swift-panel aria-labelledby=tab-group-0-1_swift-label><div class=codehilite><pre><span></span><span class=c1>// Hello, World! Program</span>
+<span class=kd>import</span> <span class=nc>Swift</span>
+<span class=bp>print</span><span class=p>(</span><span class=s>&quot;Hello, World!&quot;</span><span class=p>)</span>
+</pre></div></div></div>
+
+<p> <div class=codehilite><pre><span></span><span class=nt>&lt;interface</span> <span class=na>name=</span><span class=s>&quot;string&quot;</span> <span class=na>version=</span><span class=s>&quot;string&quot;</span> <span class=na>minVersion=</span><span class=s>&quot;string&quot;</span> <span class=na>date=</span><span class=s>&quot;string&quot;</span><span class=nt>&gt;</span>
+  <span class=c>&lt;!--Zero or more repetitions:--&gt;</span>
+  <span class=nt>&lt;enum/&gt;</span>
+  <span class=c>&lt;!--Zero or more repetitions:--&gt;</span>
+  <span class=nt>&lt;struct/&gt;</span>
+  <span class=c>&lt;!--Zero or more repetitions:--&gt;</span>
+  <span class=nt>&lt;function/&gt;</span>
+<span class=nt>&lt;/interface&gt;</span>
+</pre></div></p>"""
+
+        self.maxDiff = len(html) * 2
+        self.assertEqual(html, expected_output)
+

--- a/tests/test_scoped_code_tabs.py
+++ b/tests/test_scoped_code_tabs.py
@@ -216,3 +216,55 @@ print("Hello, World!")
         self.maxDiff = len(html) * 2
         self.assertEqual(html, expected_output)
 
+    def test_subsequent_scoped_code_tabs(self):
+        """
+        Two scoped code tab groups in direct succession with nothing in-between should still result in
+            two distinct tab groups
+        """
+        text = """\
+|~
+```objc
+- (void)hmiLevel:(SDLHMILevel)oldLevel didChangeToLevel:(SDLHMILevel)newLevel {
+}
+```
+```swift
+fileprivate var firstHMILevel: SDLHMILevel = .none
+func hmiLevel(_ oldLevel: SDLHMILevel, didChangeToLevel newLevel: SDLHMILevel) {
+}
+```
+~|
+|~
+```objc
+- (void)hmiLevel:(SDLHMILevel)oldLevel didChangeToLevel:(SDLHMILevel)newLevel {
+}
+```
+```swift
+fileprivate var firstHMILevel: SDLHMILevel = .none
+func hmiLevel(_ oldLevel: SDLHMILevel, didChangeToLevel newLevel: SDLHMILevel) {
+}
+```
+~|
+"""
+        expected_output = """\
+<div class=md-fenced-code-tabs id=tab-tab-group-0><input name=tab-group-0 type=radio id=tab-group-0-0_objc checked=checked class=code-tab data-lang=objc aria-controls=tab-group-0-0_objc-panel role=tab><label for=tab-group-0-0_objc class=code-tab-label data-lang=objc id=tab-group-0-0_objc-label>Objc</label><div class=code-tabpanel role=tabpanel data-lang=objc id=tab-group-0-0_objc-panel aria-labelledby=tab-group-0-0_objc-label><pre><code class=objc>- (void)hmiLevel:(SDLHMILevel)oldLevel didChangeToLevel:(SDLHMILevel)newLevel {
+}
+</code></pre></div><input name=tab-group-0 type=radio id=tab-group-0-1_swift class=code-tab data-lang=swift aria-controls=tab-group-0-1_swift-panel role=tab><label for=tab-group-0-1_swift class=code-tab-label data-lang=swift id=tab-group-0-1_swift-label>Swift</label><div class=code-tabpanel role=tabpanel data-lang=swift id=tab-group-0-1_swift-panel aria-labelledby=tab-group-0-1_swift-label><pre><code class=swift>fileprivate var firstHMILevel: SDLHMILevel = .none
+func hmiLevel(_ oldLevel: SDLHMILevel, didChangeToLevel newLevel: SDLHMILevel) {
+}
+</code></pre></div></div>
+
+<div class=md-fenced-code-tabs id=tab-tab-group-1><input name=tab-group-1 type=radio id=tab-group-1-0_objc checked=checked class=code-tab data-lang=objc aria-controls=tab-group-1-0_objc-panel role=tab><label for=tab-group-1-0_objc class=code-tab-label data-lang=objc id=tab-group-1-0_objc-label>Objc</label><div class=code-tabpanel role=tabpanel data-lang=objc id=tab-group-1-0_objc-panel aria-labelledby=tab-group-1-0_objc-label><pre><code class=objc>- (void)hmiLevel:(SDLHMILevel)oldLevel didChangeToLevel:(SDLHMILevel)newLevel {
+}
+</code></pre></div><input name=tab-group-1 type=radio id=tab-group-1-1_swift class=code-tab data-lang=swift aria-controls=tab-group-1-1_swift-panel role=tab><label for=tab-group-1-1_swift class=code-tab-label data-lang=swift id=tab-group-1-1_swift-label>Swift</label><div class=code-tabpanel role=tabpanel data-lang=swift id=tab-group-1-1_swift-panel aria-labelledby=tab-group-1-1_swift-label><pre><code class=swift>fileprivate var firstHMILevel: SDLHMILevel = .none
+func hmiLevel(_ oldLevel: SDLHMILevel, didChangeToLevel newLevel: SDLHMILevel) {
+}
+</code></pre></div></div>"""
+
+        html = markdown.markdown(
+            text,
+            extensions=self.MARKDOWN_EXTENSIONS,
+            output_format='html5')
+
+        self.maxDiff = len(html) * 2
+        self.assertEqual(html, expected_output)
+

--- a/tests/test_scoped_code_tabs.py
+++ b/tests/test_scoped_code_tabs.py
@@ -12,7 +12,8 @@ class ScopedCodeTabsExtensionTest(unittest.TestCase):
 
     def test_mixed_code_blocks(self):
         """
-        Tests mixed code blocks to ensure extension is only run on those with |~ ... ~| fences
+        Tests tabbed and non-tabbed code blocks to ensure extension is only run on those with |~ ... ~| fences
+            and that the indexing on tabbed HTML classes works correctly
         """
         text = """\
 ### A set of code tabs in Python and Java
@@ -22,31 +23,23 @@ class ScopedCodeTabsExtensionTest(unittest.TestCase):
 def main():
     print("This would be passed through markdown_fenced_code_tabs")
 ```
-
 ```java
 public static void main(String[] args) {
     System.out.println("This would be passed through markdown_fenced_code_tabs");
 }
 ```
 ~|
-
-### A regular, non-tabbed code block in Bash
-[comment]: # (This should render as two, non-tabbed code blocks)
 ```bash
 codeblockinfo() {
     echo("This would NOT be passed through markdown_fenced_code_tabs");
 }
 ```
-
 ```clojure
 (defn code-block-info []
    (println "This should also render as a normal code block"))
 (hello-world)
 ```
-
-#### (White-space fences are OK)
-[comment]: # (This should render as two more fenced code tabs even with whitespace around the fences)
-  |~
+|~
 ```html
 <html>
 <head></head>
@@ -55,13 +48,12 @@ codeblockinfo() {
 </body>
 </html>
 ```
-
 ```python
 def hello_world(name: str = None):
     greeting = name or 'World'
     return f'Hello {greeting}!'
 ```
- ~|
+~|
 """
         expected_output = """\
 <h3>A set of code tabs in Python and Java</h3>
@@ -72,23 +64,21 @@ def hello_world(name: str = None):
 }
 </code></pre></div></div>
 
-<h3>A regular, non-tabbed code block in Bash</h3>
-<div class=md-fenced-code-tabs id=tab-tab-group-0><input name=tab-group-0 type=radio id=tab-group-0-0_bash checked=checked class=code-tab data-lang=bash aria-controls=tab-group-0-0_bash-panel role=tab><label for=tab-group-0-0_bash class=code-tab-label data-lang=bash id=tab-group-0-0_bash-label>Bash</label><div class=code-tabpanel role=tabpanel data-lang=bash id=tab-group-0-0_bash-panel aria-labelledby=tab-group-0-0_bash-label><pre><code class=bash>codeblockinfo() {
-    echo(&quot;This would NOT be passed through markdown_fenced_code_tabs&quot;);
-}
-</code></pre></div><input name=tab-group-0 type=radio id=tab-group-0-1_clojure class=code-tab data-lang=clojure aria-controls=tab-group-0-1_clojure-panel role=tab><label for=tab-group-0-1_clojure class=code-tab-label data-lang=clojure id=tab-group-0-1_clojure-label>Clojure</label><div class=code-tabpanel role=tabpanel data-lang=clojure id=tab-group-0-1_clojure-panel aria-labelledby=tab-group-0-1_clojure-label><pre><code class=clojure>(defn code-block-info []
-   (println &quot;This should also render as a normal code block&quot;))
-(hello-world)
-</code></pre></div></div>
-
-<h4>(White-space fences are OK)</h4>
-<div class=md-fenced-code-tabs id=tab-tab-group-0><input name=tab-group-0 type=radio id=tab-group-0-0_html checked=checked class=code-tab data-lang=html aria-controls=tab-group-0-0_html-panel role=tab><label for=tab-group-0-0_html class=code-tab-label data-lang=html id=tab-group-0-0_html-label>Html</label><div class=code-tabpanel role=tabpanel data-lang=html id=tab-group-0-0_html-panel aria-labelledby=tab-group-0-0_html-label><pre><code class=html>&lt;html&gt;
+<p><code>bash
+codeblockinfo() {
+    echo("This would NOT be passed through markdown_fenced_code_tabs");
+}</code>
+<code>clojure
+(defn code-block-info []
+   (println "This should also render as a normal code block"))
+(hello-world)</code></p>
+<div class=md-fenced-code-tabs id=tab-tab-group-1><input name=tab-group-1 type=radio id=tab-group-1-0_html checked=checked class=code-tab data-lang=html aria-controls=tab-group-1-0_html-panel role=tab><label for=tab-group-1-0_html class=code-tab-label data-lang=html id=tab-group-1-0_html-label>Html</label><div class=code-tabpanel role=tabpanel data-lang=html id=tab-group-1-0_html-panel aria-labelledby=tab-group-1-0_html-label><pre><code class=html>&lt;html&gt;
 &lt;head&gt;&lt;/head&gt;
 &lt;body&gt;
     &lt;p&gt;Hello {{ greeting|default:&quot;World&quot; }}!&lt;/p&gt;
 &lt;/body&gt;
 &lt;/html&gt;
-</code></pre></div><input name=tab-group-0 type=radio id=tab-group-0-1_python class=code-tab data-lang=python aria-controls=tab-group-0-1_python-panel role=tab><label for=tab-group-0-1_python class=code-tab-label data-lang=python id=tab-group-0-1_python-label>Python</label><div class=code-tabpanel role=tabpanel data-lang=python id=tab-group-0-1_python-panel aria-labelledby=tab-group-0-1_python-label><pre><code class=python>def hello_world(name: str = None):
+</code></pre></div><input name=tab-group-1 type=radio id=tab-group-1-1_python class=code-tab data-lang=python aria-controls=tab-group-1-1_python-panel role=tab><label for=tab-group-1-1_python class=code-tab-label data-lang=python id=tab-group-1-1_python-label>Python</label><div class=code-tabpanel role=tabpanel data-lang=python id=tab-group-1-1_python-panel aria-labelledby=tab-group-1-1_python-label><pre><code class=python>def hello_world(name: str = None):
     greeting = name or 'World'
     return f'Hello {greeting}!'
 </code></pre></div></div>"""
@@ -132,7 +122,11 @@ def hello_world(greeting: str = 'World'):
         self.maxDiff = len(html) * 2
         self.assertEqual(html, expected_output)
 
-    def test_fenced_code_mixed_hilite(self):
+    def test_fenced_code_mixed_hilite_and_fenced_code(self):
+        """
+        Tests that the base fenced_code_block preprocessor is not replaced by code tabs
+            and that the hilite library is properly loaded when used
+        """
         text = """\
 |~
 ```objc
@@ -146,14 +140,22 @@ int main(int argc, const char * argv[]) {
     return 0;
 }
 ```
-
 ```swift
 // Hello, World! Program
 import Swift
 print("Hello, World!")
 ```
 ~|
-
+```xml
+<interface name="string" version="string" minVersion="string" date="string">
+  <!--Zero or more repetitions:-->
+  <enum/>
+  <!--Zero or more repetitions:-->
+  <struct/>
+  <!--Zero or more repetitions:-->
+  <function/>
+</interface>
+```
 ```xml
 <interface name="string" version="string" minVersion="string" date="string">
   <!--Zero or more repetitions:-->
@@ -190,15 +192,26 @@ print("Hello, World!")
 <span class=bp>print</span><span class=p>(</span><span class=s>&quot;Hello, World!&quot;</span><span class=p>)</span>
 </pre></div></div></div>
 
-<p> <div class=codehilite><pre><span></span><span class=nt>&lt;interface</span> <span class=na>name=</span><span class=s>&quot;string&quot;</span> <span class=na>version=</span><span class=s>&quot;string&quot;</span> <span class=na>minVersion=</span><span class=s>&quot;string&quot;</span> <span class=na>date=</span><span class=s>&quot;string&quot;</span><span class=nt>&gt;</span>
-  <span class=c>&lt;!--Zero or more repetitions:--&gt;</span>
-  <span class=nt>&lt;enum/&gt;</span>
-  <span class=c>&lt;!--Zero or more repetitions:--&gt;</span>
-  <span class=nt>&lt;struct/&gt;</span>
-  <span class=c>&lt;!--Zero or more repetitions:--&gt;</span>
-  <span class=nt>&lt;function/&gt;</span>
-<span class=nt>&lt;/interface&gt;</span>
-</pre></div></p>"""
+<div class="codehilite"><pre><span></span><span class="nt">&lt;interface</span> <span class="na">name=</span><span class="s">&quot;string&quot;</span> <span class="na">version=</span><span class="s">&quot;string&quot;</span> <span class="na">minVersion=</span><span class="s">&quot;string&quot;</span> <span class="na">date=</span><span class="s">&quot;string&quot;</span><span class="nt">&gt;</span>
+  <span class="c">&lt;!--Zero or more repetitions:--&gt;</span>
+  <span class="nt">&lt;enum/&gt;</span>
+  <span class="c">&lt;!--Zero or more repetitions:--&gt;</span>
+  <span class="nt">&lt;struct/&gt;</span>
+  <span class="c">&lt;!--Zero or more repetitions:--&gt;</span>
+  <span class="nt">&lt;function/&gt;</span>
+<span class="nt">&lt;/interface&gt;</span>
+</pre></div>
+
+
+<div class="codehilite"><pre><span></span><span class="nt">&lt;interface</span> <span class="na">name=</span><span class="s">&quot;string&quot;</span> <span class="na">version=</span><span class="s">&quot;string&quot;</span> <span class="na">minVersion=</span><span class="s">&quot;string&quot;</span> <span class="na">date=</span><span class="s">&quot;string&quot;</span><span class="nt">&gt;</span>
+  <span class="c">&lt;!--Zero or more repetitions:--&gt;</span>
+  <span class="nt">&lt;enum/&gt;</span>
+  <span class="c">&lt;!--Zero or more repetitions:--&gt;</span>
+  <span class="nt">&lt;struct/&gt;</span>
+  <span class="c">&lt;!--Zero or more repetitions:--&gt;</span>
+  <span class="nt">&lt;function/&gt;</span>
+<span class="nt">&lt;/interface&gt;</span>
+</pre></div>"""
 
         self.maxDiff = len(html) * 2
         self.assertEqual(html, expected_output)


### PR DESCRIPTION
Basically, the removal of the fenced code extension after loading it was not limited to within this extension, but across the markdown, which means removing it from the whole list of extensions wherever this library is used. Which is not good.